### PR TITLE
Breaking chore: remove `data['result']` inside `AccessTokenResponse.fromMap()`

### DIFF
--- a/lib/features/access_token/datas/models/access_token_response.dart
+++ b/lib/features/access_token/datas/models/access_token_response.dart
@@ -8,8 +8,8 @@ class AccessTokenResponse extends AccessTokenEntity {
 
   factory AccessTokenResponse.fromMap(Map<String, dynamic> data) {
     return AccessTokenResponse(
-      accessToken: data['result']['accessToken'] as String?,
-      refreshToken: data['result']['refreshToken'] as String?,
+      accessToken: data['accessToken'] as String?,
+      refreshToken: data['refreshToken'] as String?,
     );
   }
 }

--- a/lib/features/authorize/datas/datasources/authorize_remote_data_source.dart
+++ b/lib/features/authorize/datas/datasources/authorize_remote_data_source.dart
@@ -24,7 +24,7 @@ class AuthorizeRemoteDataSourceImp implements AuthorizeRemoteDataSource {
   TaskEither<Failure, AccessTokenEntity?> authorize(params) {
     return _client.post(
       path: Endpoints.authorize,
-      converter: (resp) => AccessTokenResponse.fromMap(resp),
+      converter: (resp) => AccessTokenResponse.fromMap(resp['result']),
       body: params.toMap(),
     );
   }

--- a/test/features/access_token/datas/models/access_token_response_test.dart
+++ b/test/features/access_token/datas/models/access_token_response_test.dart
@@ -27,7 +27,8 @@ void main() {
     });
 
     test('should return datas from response', () {
-      final AccessTokenResponse result = AccessTokenResponse.fromMap(data);
+      final AccessTokenResponse result =
+          AccessTokenResponse.fromMap(data['result']);
 
       expect(result, response);
     });

--- a/test/features/authorize/datas/datasources/authorize_remote_data_source_test.dart
+++ b/test/features/authorize/datas/datasources/authorize_remote_data_source_test.dart
@@ -67,7 +67,7 @@ void main() {
 
       (await dataSourceImp.authorize(params).run()).match(
         (l) => null,
-        (r) => AccessTokenResponse.fromMap(success),
+        (r) => AccessTokenResponse.fromMap(success['result']),
       );
     });
 


### PR DESCRIPTION
# Description

 Remove `data['result']` inside `AccessTokenResponse.fromMap()`

# Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore